### PR TITLE
Support aarch64 and remove `@plt`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,14 @@ on:
   pull_request: {}
   push:
     branches:
-      - master
+      - main
 
 jobs:
 
   test:
     name: CI
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out code
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install -y \
-            fp-compiler-3.0.4
+            fp-compiler-3.2.2
 
       - name: Compile
         run: sbt test:compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,15 @@ jobs:
 
       - name: Install dependencies
         run: |
+          wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+          sudo dpkg -i packages-microsoft-prod.deb
+          rm packages-microsoft-prod.deb
+          sudo apt update -y
           sudo apt-get install -y \
-            fp-compiler-3.2.2
+            fp-compiler-3.2.2 \
+            openjdk-17-jdk \
+            openjdk-17-source \
+            dotnet-sdk-7.0
 
       - name: Compile
         run: sbt test:compile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,12 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
         run: |
           git tag -f ${{ steps.bump-version.outputs.tag }}
           sbt proguard:proguard
-          mv ./target/scala-2.11/proguard/libinteractive_2.11-*.jar \
-             ./target/scala-2.11/proguard/libinteractive.jar
+          mv ./target/scala-2.12/proguard/libinteractive_2.12-*.jar \
+             ./target/scala-2.12/proguard/libinteractive.jar
 
       - name: Create Release
         id: create-release
@@ -48,6 +48,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./target/scala-2.11/proguard/libinteractive.jar
+          asset_path: ./target/scala-2.12/proguard/libinteractive.jar
           asset_name: libinteractive.jar
           asset_content_type: application/octet-stream

--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,17 @@
 name := "libinteractive"
 
+organization := "com.omegaup"
+
+scalaVersion := "2.12.17"
+
+ThisBuild / scalaVersion := scalaVersion.value
+ThisProject / scalaVersion := scalaVersion.value
+
+scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
+
 enablePlugins(GitVersioning)
 
 git.useGitDescribe := true
-
-organization := "com.omegaup"
-
-scalaVersion := "2.11.5"
-
-scalaVersion in ThisProject := "2.11.5"
-
-scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
 lazy val root = (project in file("."))
 	.enablePlugins(SbtTwirl)
@@ -22,7 +23,7 @@ lazy val root = (project in file("."))
 
 publishMavenStyle := true
 
-publishArtifact in Test := false
+Test / publishArtifact := false
 
 publishTo := {
 	val nexus = "https://oss.sonatype.org/"
@@ -60,46 +61,41 @@ TwirlKeys.templateFormats += ("code" -> "com.omegaup.libinteractive.templates.Co
 
 exportJars := true
 
-packageOptions in (Compile, packageBin) +=
+Compile / packageBin / packageOptions +=
 	Package.ManifestAttributes( java.util.jar.Attributes.Name.MAIN_CLASS -> "com.omegaup.libinteractive.Main" )
 
-mappings in (Compile, packageBin) ++= Seq(
+Compile / packageBin / mappings ++= Seq(
 	(baseDirectory.value / "LICENSE") -> "LICENSE",
 	(baseDirectory.value / "NOTICE") -> "NOTICE"
 )
 
 libraryDependencies ++= Seq(
-	"com.github.scopt" %% "scopt" % "3.2.0",
+	"com.github.scopt" %% "scopt" % "3.7.1",
 	"org.apache.commons" % "commons-compress" % "1.8.1",
-	"org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.3",
-	"org.scalatest" %% "scalatest" % "2.2.4" % "test"
+	"org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.7",
+	"org.scalatest" %% "scalatest" % "3.0.4" % "test"
 )
 
 resolvers += Resolver.sonatypeRepo("public")
 
-proguardSettings
+enablePlugins(SbtProguard)
 
-ProguardKeys.options in Proguard ++= Seq(
+(Proguard / proguardOptions) ++= Seq(
   "-dontskipnonpubliclibraryclasses",
   "-dontskipnonpubliclibraryclassmembers",
   "-dontoptimize",
   "-dontobfuscate",
-  "-dontpreverify",
   "-dontnote",
   "-dontwarn",
   "-keep interface scala.ScalaObject",
   "-keep class com.omegaup.libinteractive.**",
   "-keep class scala.collection.JavaConversions",
-  ProguardOptions.keepMain("com.omegaup.libinteractive.Main")
 )
-
-ProguardKeys.inputFilter in Proguard := { file =>
+(Proguard / proguardOptions) += ProguardOptions.keepMain("com.omegaup.libinteractive.Main")
+(Proguard / proguardInputFilter) := { file =>
   file.name match {
     case s if s.startsWith("libinteractive") => None
     case _ => Some("!META-INF/MANIFEST.MF,!META-INF/LICENSE.txt,!META-INF/NOTICE.txt,!rootdoc.txt")
   }
 }
-
-ProguardKeys.proguardVersion in Proguard := "5.0"
-
-javaOptions in (Proguard, ProguardKeys.proguard) := Seq("-Xmx2G")
+(Proguard / proguardVersion) := "7.3.1"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,9 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
+scalaVersion := "2.12.17"
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-proguard" % "0.2.2")
+addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.0.4")
+addSbtPlugin("com.github.sbt" % "sbt-proguard" % "0.5.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.4.0")
+addSbtPlugin("com.typesafe.play" % "sbt-twirl" % "1.5.2")
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")

--- a/src/main/scala/com/omegaup/libinteractive/targets/CSharp.scala
+++ b/src/main/scala/com/omegaup/libinteractive/targets/CSharp.scala
@@ -47,9 +47,9 @@ class CSharp(idl: IDL, options: Options, input: Path, parent: Boolean)
 	override def generateMakefileRules(interface: Interface) = {
 		val configuration = (if (options.generateDebugTargets) "Debug" else "Release")
 		val targetPath = (if (interface == idl.main) {
-			options.relativeToRoot(interface.name, s"bin/${configuration}/netcoreapp2.0/${interface.name}.dll")
+			options.relativeToRoot(interface.name, s"bin/${configuration}/netcoreapp7.0/${interface.name}.dll")
 		} else {
-			options.relativeToRoot(interface.name, s"bin/${configuration}/netcoreapp2.0/${interface.name}.dll")
+			options.relativeToRoot(interface.name, s"bin/${configuration}/netcoreapp7.0/${interface.name}.dll")
 		})
 		val mainSourcePath = (if (interface == idl.main) {
 			options.relativeToRoot(interface.name, s"${interface.name}.cs")

--- a/src/main/scala/com/omegaup/libinteractive/targets/Java.scala
+++ b/src/main/scala/com/omegaup/libinteractive/targets/Java.scala
@@ -67,7 +67,7 @@ class Java(idl: IDL, options: Options, input: Path, parent: Boolean)
 				options.relativeToRoot(interface.name, s"${interface.name}_entry.java")
 			),
 			compiler = Compiler.Javac,
-			params = List("$^")
+			params = List("-d", options.relativeToRoot(interface.name).toString(), "$^")
 		))
 	}
 

--- a/src/main/scala/com/omegaup/libinteractive/targets/Python.scala
+++ b/src/main/scala/com/omegaup/libinteractive/targets/Python.scala
@@ -225,7 +225,7 @@ import ${idl.main.name}  # pylint: disable=unused-import"""
 					s"${formatLength(head, function)} * ${fieldLength(primitive)})"
 			case head :: tail =>
 				s"[${readArray(infd, primitive, tail, function, depth + 1)} " +
-					s"for __r$depth in xrange(${formatLength(head, function)})]"
+					s"for __r$depth in range(${formatLength(head, function)})]"
 		}
 	}
 

--- a/src/main/twirl/com/omegaup/libinteractive/templates/c_main.scala.code
+++ b/src/main/twirl/com/omegaup/libinteractive/templates/c_main.scala.code
@@ -97,6 +97,7 @@ void _entry() __attribute__ ((alias ("__entry")));
 // OS X makes it harder to define the entrypoint in pure assembly, so let's
 // rely on using a real C function with inline assembly.
 void _entry() {
+#if defined(__x86_64__)
 	__asm__(
 		"popq %%rbp\n"  // Remove %rbp from the stack that gcc helpfully added.
 		"pushq %%rdx\n" // Store %rdx since we will need it later.
@@ -104,6 +105,23 @@ void _entry() {
 		"popq %%rdx\n"
 		"jmp _main\n"
 		:::
+#elif defined(__ARM64_ARCH_8__)
+		"sub sp, sp, #64\n"
+		"stp x0, x1, [sp]\n"
+		"stp x2, x3, [sp,#16]\n"
+		"stp x4, x5, [sp,#32]\n"
+		"stp x6, x7, [sp,#48]\n"
+		"bl ___libinteractive_init\n"
+		"ldp x0, x1, [sp]\n"
+		"ldp x2, x3, [sp,#16]\n"
+		"ldp x4, x5, [sp,#32]\n"
+		"ldp x6, x7, [sp,#48]\n"
+		"add sp, sp, #64\n"
+		"b _main\n"
+		:::
+#else
+#error libinteractive is not supported in your architecture
+#endif
 	);
 }
 

--- a/src/main/twirl/com/omegaup/libinteractive/templates/c_main_entry.scala.code
+++ b/src/main/twirl/com/omegaup/libinteractive/templates/c_main_entry.scala.code
@@ -3,9 +3,9 @@
 // @c.message
 #if !defined(__APPLE__)
 
-	.global __entry
-
 	.text
+
+	.global __entry
 
 // _start expects the stack and registers in a special configuration.
 // We do libinteractive initialization in assembly to avoid touching
@@ -21,7 +21,7 @@ __entry:
 	call __libinteractive_init
 	add $0x8,%rsp
 	popq %rdx
-	jmp _start@@plt
+	jmp _start
 
 	hlt
 #elif defined(__i386__)
@@ -32,14 +32,29 @@ __entry:
 	popl %ecx
 	popl %edx
 	popl %eax
-	jmp _start@@plt
+	jmp _start
 
 	hlt
 #elif defined(__ARM_ARCH_7A__)
 	push {r0-r3}
 	bl __libinteractive_init
 	pop {r0-r3}
-	b _start@@plt
+	b _start
+
+	udf #255
+#elif defined(__ARM_ARCH_8A)
+	sub sp, sp, #64
+	stp x0, x1, [sp]
+	stp x2, x3, [sp,#16]
+	stp x4, x5, [sp,#32]
+	stp x6, x7, [sp,#48]
+	bl __libinteractive_init
+	ldp x0, x1, [sp]
+	ldp x2, x3, [sp,#16]
+	ldp x4, x5, [sp,#32]
+	ldp x6, x7, [sp,#48]
+	add sp, sp, #64
+	b _start
 
 	udf #255
 #else

--- a/src/main/twirl/com/omegaup/libinteractive/templates/cs_csproj.scala.code
+++ b/src/main/twirl/com/omegaup/libinteractive/templates/cs_csproj.scala.code
@@ -15,7 +15,7 @@
     <Configuration>Release</Configuration>
 }
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp7.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/main/twirl/com/omegaup/libinteractive/templates/python.scala.code
+++ b/src/main/twirl/com/omegaup/libinteractive/templates/python.scala.code
@@ -19,7 +19,7 @@ import transact
 def __readarray(infd, fmt, length):
     "@{'"'}"Reads an array from infd."@{'"'}"
     arr = array.array(fmt)
-    arr.fromstring(infd.read(length))
+    arr.frombytes(infd.read(length))
     return arr
 
 @if(options.transact) {

--- a/src/main/twirl/com/omegaup/libinteractive/templates/python_main.scala.code
+++ b/src/main/twirl/com/omegaup/libinteractive/templates/python_main.scala.code
@@ -20,7 +20,7 @@ import transact
 def __readarray(infd, fmt, length):
     "@{'"'}"Reads an array from infd."@{'"'}"
     arr = array.array(fmt)
-    arr.fromstring(infd.read(length))
+    arr.frombytes(infd.read(length))
     return arr
 
 @if(options.transact) {

--- a/src/test/resources/mega/Main.py
+++ b/src/test/resources/mega/Main.py
@@ -17,14 +17,14 @@ def send(num_rows, encoded):
 
 def output(num_rows, solution):
     """Outputs the final solution."""
-    for i in xrange(num_rows):
+    for i in range(num_rows):
         print(solution[i])
 
 def main():
     """Driver for the contestant's code."""
     print("%.2f" % mega.solve(1, 2, -3, 4.25, 5.75))
     matrix = [range(NUM_ROWS * row, NUM_ROWS * (row + 1))
-              for row in xrange(NUM_ROWS)]
+              for row in range(NUM_ROWS)]
     print(matrix, file=sys.stderr)
     mega.encode(NUM_ROWS, matrix)
 

--- a/src/test/resources/mega/mega.py
+++ b/src/test/resources/mega/mega.py
@@ -6,14 +6,14 @@ import Main
 
 def encode(num_rows, matrix):
     """Encodes the matrix."""
-    for i in xrange(num_rows):
-        for j in xrange(num_rows):
+    for i in range(num_rows):
+        for j in range(num_rows):
             matrix[i][j] *= 2
     Main.send(num_rows, matrix)
 
 def decode(num_rows, encoded):
     """Decodes the matrix."""
-    for i in xrange(num_rows):
+    for i in range(num_rows):
         encoded[i] *= 2
     Main.output(num_rows, encoded)
 

--- a/src/test/scala/ParserSpec.scala
+++ b/src/test/scala/ParserSpec.scala
@@ -83,7 +83,7 @@ class ParserSpec extends FlatSpec with Matchers {
 	it should "throw ParseExceptions" in {
 		intercept[ParseException] { parser.parse("""
 				interface Main;""")
-		}.getMessage should be("``{'' expected but `;' found")
+		}.getMessage should be("'`{'' expected but `;' found")
 
 		intercept[ParseException] { parser.parse("""
 			interface Main {


### PR DESCRIPTION
This change allows compilation in aarch64 (ARMv8 with 64 bits, M1/M2 chips for macOs). It also removes the `@plt` suffix for `_start` because it appears that it's no longer used today.